### PR TITLE
Prevents null-pointer exception if server is not yet initialised

### DIFF
--- a/src/codeanticode/syphon/SyphonServer.java
+++ b/src/codeanticode/syphon/SyphonServer.java
@@ -93,6 +93,9 @@ public class SyphonServer {
    * @return boolean 
    */    
   public boolean hasClients() {
+    if(server == null)
+      return false;
+
     return server.hasClients();
   }	
 	


### PR DESCRIPTION
Prevents null-pointer exception if the server not yet has been initialised. This happens if the user try's to check if there are clients before sending out an image.

```java
void sendImageIfNecessary(PImage img) {
    if(syphon.hasClients())
        syphon.sendImage(img);
}
```

In this example we check if syphon has clients connected, but because the  `sendImage` command was never called, the `server` is not initialised.