### PR TITLE
Added explicit start method to syphon server

### DIFF
--- a/src/codeanticode/syphon/SyphonServer.java
+++ b/src/codeanticode/syphon/SyphonServer.java
@@ -10,17 +10,17 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General
  * Public License along with this library; if not, write to the
  * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
  * Boston, MA  02111-1307  USA
- * 
+ *
  * @author		##author##
  * @modified	##date##
  * @version		##version##
@@ -33,7 +33,7 @@ import processing.opengl.*;
 import jsyphon.*;
 
 /**
- * Syphon server class. It broadcasts the textures encapsulated in 
+ * Syphon server class. It broadcasts the textures encapsulated in
  * PImage objects.
  *
  */
@@ -42,13 +42,13 @@ public class SyphonServer {
 	protected PGraphicsOpenGL pg;
 	protected JSyphonServer server;
 	protected String serverName;
-	
+
   /**
    * Constructor that sets server with specified name.
-   * 
+   *
    * @param parent
-   * @param serverName
-   */	
+   * @param name
+   */
   public SyphonServer(PApplet parent, String name) {
     this.parent = parent;
     pg = (PGraphicsOpenGL)parent.g;
@@ -56,8 +56,8 @@ public class SyphonServer {
     Syphon.init();
     parent.registerMethod("dispose", this);
   }
-  
-  
+
+
 
   /**
    * Initialises the underlying JSyphon server.
@@ -66,15 +66,9 @@ public class SyphonServer {
    */
   public void init()
   {
-    Texture tex = pg.getTexture(source);
-    if (tex != null) {
-      if (server == null) {
-        server = new JSyphonServer();
-        server.initWithName(serverName);
-      }
-    }
-    else {
-      PGraphics.showWarning("Texture is null");
+    if (server == null) {
+      server = new JSyphonServer();
+      server.initWithName(serverName);
     }
   }
 
@@ -84,17 +78,17 @@ public class SyphonServer {
    * sure that the server is properly stopped and Syphon doesn't complain about
    * memory not being properly released:
    * https://github.com/Syphon/Processing/issues/4
-   * 
+   *
    */
   public void dispose() {
     server.stop();
-  } 
-	
-  
+  }
+
+
   /**
-   * The class finalizer tries to make sure that the server is stopped. No 
+   * The class finalizer tries to make sure that the server is stopped. No
    * guarantee that this method is ever called by the GC, but just in case.
-   * 
+   *
    */
   protected void finalize() throws Throwable {
     try {
@@ -104,30 +98,30 @@ public class SyphonServer {
     } finally {
       super.finalize();
     }
-  }  
-  
-  
+  }
+
+
   /**
    * Returns true if this server is bound to any
    * client.
-   * 
-   * @return boolean 
-   */    
+   *
+   * @return boolean
+   */
   public boolean hasClients() {
     // lazy init server
     if(server == null)
       init();
 
     return server.hasClients();
-  }	
-	
-  
+  }
+
+
   /**
    * Sends the source image to the bound client
    * and lazy initialises the JSyphon server.
    *
    * @param source
-   */ 	
+   */
   public void sendImage(PImage source) {
     if (parent.frameCount == 0) {
       PGraphics.showWarning("Only can send frames in draw()");
@@ -142,32 +136,33 @@ public class SyphonServer {
     // send frame if texture is available
     Texture tex = pg.getTexture(source);
     if (tex != null) {
-      server.publishFrameTexture(tex.glName, tex.glTarget, 
-                                 0, 0, tex.glWidth, tex.glHeight, 
+      server.publishFrameTexture(tex.glName, tex.glTarget,
+                                 0, 0, tex.glWidth, tex.glHeight,
                                  tex.glWidth, tex.glHeight, false);
     } else {
       PGraphics.showWarning("Texture is null");
     }
-  }	
-  
-  
+  }
+
+
   /**
    * Sends the screen image to the bound client.
-   * 
-   */   
+   *
+   */
   public void sendScreen() {
     // Should use enableFBOLayer() instead...
     pg.pgl.requestFBOLayer();
-    sendImage(pg);    
+    sendImage(pg);
   }
-  
-  
+
+
   /**
    * Stops the server.
-   * 
-   */  
+   *
+   */
   public void stop() {
     server.stop();
+    server = null;
   }
 }
 

--- a/src/codeanticode/syphon/SyphonServer.java
+++ b/src/codeanticode/syphon/SyphonServer.java
@@ -60,15 +60,21 @@ public class SyphonServer {
   
 
   /**
-   * Starts the underlying JSyphon server.
+   * Initialises the underlying JSyphon server.
    * The server needs to be created after setup
    * and all the JOGL initialization has taken place.
    */
-  public void start()
+  public void init()
   {
-    if (server == null) {
-      server = new JSyphonServer();
-      server.initWithName(serverName);
+    Texture tex = pg.getTexture(source);
+    if (tex != null) {
+      if (server == null) {
+        server = new JSyphonServer();
+        server.initWithName(serverName);
+      }
+    }
+    else {
+      PGraphics.showWarning("Texture is null");
     }
   }
 
@@ -108,8 +114,9 @@ public class SyphonServer {
    * @return boolean 
    */    
   public boolean hasClients() {
+    // lazy init server
     if(server == null)
-      return false;
+      init();
 
     return server.hasClients();
   }	
@@ -126,13 +133,15 @@ public class SyphonServer {
       PGraphics.showWarning("Only can send frames in draw()");
       return;
     }
-    
+
+    // lazy init server
+    if (server == null) {
+      init();
+    }
+
+    // send frame if texture is available
     Texture tex = pg.getTexture(source);
     if (tex != null) {
-      if (server == null) {
-        start();
-      }
-      
       server.publishFrameTexture(tex.glName, tex.glTarget, 
                                  0, 0, tex.glWidth, tex.glHeight, 
                                  tex.glWidth, tex.glHeight, false);

--- a/src/codeanticode/syphon/SyphonServer.java
+++ b/src/codeanticode/syphon/SyphonServer.java
@@ -124,7 +124,7 @@ public class SyphonServer {
   
   /**
    * Sends the source image to the bound client
-   * and lazy initialises the JSyphon sever.
+   * and lazy initialises the JSyphon server.
    *
    * @param source
    */ 	

--- a/src/codeanticode/syphon/SyphonServer.java
+++ b/src/codeanticode/syphon/SyphonServer.java
@@ -64,7 +64,7 @@ public class SyphonServer {
    * The server needs to be created after setup
    * and all the JOGL initialization has taken place.
    */
-  public void init()
+  private void init()
   {
     if (server == null) {
       server = new JSyphonServer();

--- a/src/codeanticode/syphon/SyphonServer.java
+++ b/src/codeanticode/syphon/SyphonServer.java
@@ -58,6 +58,21 @@ public class SyphonServer {
   }
   
   
+
+  /**
+   * Starts the underlying JSyphon server.
+   * The server needs to be created after setup
+   * and all the JOGL initialization has taken place.
+   */
+  public void start()
+  {
+    if (server == null) {
+      server = new JSyphonServer();
+      server.initWithName(serverName);
+    }
+  }
+
+
   /**
    * This method is called automatically when the sketch is disposed, so making
    * sure that the server is properly stopped and Syphon doesn't complain about
@@ -98,8 +113,9 @@ public class SyphonServer {
 	
   
   /**
-   * Sends the source image to the bound client.
-   * 
+   * Sends the source image to the bound client
+   * and lazy initialises the JSyphon sever.
+   *
    * @param source
    */ 	
   public void sendImage(PImage source) {
@@ -111,11 +127,7 @@ public class SyphonServer {
     Texture tex = pg.getTexture(source);
     if (tex != null) {
       if (server == null) {
-        // The server needs to be created after setup and all the 
-        // JOGL initialization has taken place. Otherwise frame
-        // sending doesn't work...
-        server = new JSyphonServer();
-        server.initWithName(serverName);        
+        start();
       }
       
       server.publishFrameTexture(tex.glName, tex.glTarget, 


### PR DESCRIPTION
Adds an explicit start method to the syphon sever as discussed in #34 .

```java
Texture tex = pg.getTexture(source);
if (tex != null) {
  if (server == null) {
    start();
  }
```

The check if the server is null in the  `sendImage` method is intended, because we can prevent a method invocation just for the same check in `start` and save a bit of performance.