### PR TITLE
Support for pixelDensity(2)

### DIFF
--- a/src/codeanticode/syphon/SyphonClient.java
+++ b/src/codeanticode/syphon/SyphonClient.java
@@ -290,7 +290,7 @@ public class SyphonClient {
     int texHeight = img.textureHeight();
 
     if (dest == null || dest.width != texWidth || dest.height != texHeight) {            
-      dest = parent.createImage(texWidth, texHeight, PConstants.ARGB);
+      dest = parent.createImage(texWidth*parent.pixelDensity, texHeight*parent.pixelDensity, PConstants.ARGB);
     }
         
     if (tempDest == null || tempDest.width != texWidth || tempDest.height != texHeight) {            


### PR DESCRIPTION
Unlike PGraphics, the PImage object doesn't cater for pixel densities other than 1 - more info on this decision here: [https://github.com/processing/processing/issues/3364](https://github.com/processing/processing/issues/3364). It causes a mismatch in dimensions as `getImage()` uses both object types to set sizes of textures the frame they are applied to. When `pixelDensity(2)` is set in the main sketch, the library throws an error.

This fix smooths things over by multiplying the image dimensions by the current set `pixelDensity`. The result is a smaller frame in the context of the sketch, but it can be easily remedied within the Processing sketch (i.e. to resize the image coming from Syphon) and better than not working at all!